### PR TITLE
Get ems vals dict feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 *.pyc
 
 */out
+
+/docs
+/simple_office_5zone_building_model

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ This is a simple example to show how to set up and simulation and utilize some o
 This implements simple rule-based thermostat control based on the time of day, for a single zone of a 5-zone office
 building. Other data is tracked and reported just for example.
 
-This is a simplified/cleaned version (no MdpManager, less comments, etc.) of the 'simple_emspy_control.py' example
+This is a simplified/cleaned version (no MdpManager, less comments, etc.) of the 'simple_emspy_control.py' example,
+meant for the README.md.
 """
-
 import datetime
 import matplotlib.pyplot as plt
 
@@ -162,6 +162,8 @@ idf_file_name = r'BEM_simple/simple_office_5zone_April.idf'  # building energy m
 # Weather Path
 ep_weather_path = r'BEM_simple/5B_USA_CO_BOULDER_TMY2.epw'  # EPW weather file
 
+# Output .csv Path (optional)
+cvs_output_path = r'dataframes_output_test.csv'
 
 # STATE SPACE (& Auxiliary Simulation Data)
 
@@ -315,7 +317,7 @@ sim.run_env(ep_weather_path)
 sim.reset_state()  # reset when done
 
 # -- Sample Output Data --
-output_dfs = sim.get_df()  # LOOK at all the data collected here, custom DFs can be made too
+output_dfs = sim.get_df(to_csv_file=cvs_output_path)  # LOOK at all the data collected here, custom DFs can be made too
 
 # -- Plot Results --
 fig, ax = plt.subplots()
@@ -327,8 +329,6 @@ output_dfs['actuator'].plot(y='zn0_cooling_sp', use_index=True, ax=ax)
 plt.title('Zn0 Temps and Thermostat Setpoint for Year')
 
 # Analyze results in "out" folder, DView, or directly from your Python variables and Pandas Dataframes
-
-
 ```
 <ins>5 Zone Office Building Model</ins>
 

--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ This is a simple example to show how to set up and simulation and utilize some o
 This implements simple rule-based thermostat control based on the time of day, for a single zone of a 5-zone office
 building. Other data is tracked and reported just for example.
 
-This is a simplified/cleaned version (no MdpManager, less comments, etc.) of the 'simple_emspy_control.py' example,
-meant for the README.md.
+This is a simplified/cleaned version (no MdpManager, less comments, etc.) of the 'simple_emspy_control.py' example
 """
+
 import datetime
 import matplotlib.pyplot as plt
 
@@ -220,6 +220,7 @@ sim = BcaEnv(
     tc_weather=tc_weather
 )
 
+
 class Agent:
     """
     Create agent instance, which is used to create actuation() and observation() functions (both optional) and maintain
@@ -241,20 +242,23 @@ class Agent:
 
         # Get data from simulation at current timestep (and calling point) using ToC names
         var_data = self.bca.get_ems_data(list(self.bca.tc_var.keys()))
-        meter_data = self.bca.get_ems_data(list(self.bca.tc_meter.keys()))
-        weather_data = self.bca.get_ems_data(list(self.bca.tc_weather.keys()))
+        meter_data = self.bca.get_ems_data(list(self.bca.tc_meter.keys()), return_dict=True)
+        weather_data = self.bca.get_ems_data(list(self.bca.tc_weather.keys()), return_dict=True)
 
         # get specific values from MdpManager based on name
         self.zn0_temp = var_data[1]  # index 1st element to get zone temps, based on EMS Variable ToC
-        # OR
-        self.zn0_temp = self.bca.get_ems_data(['zn0_temp'])
+        # OR if using "return_dict=True"
+        outdoor_temp = weather_data['oa_db']  # outdoor air dry bulb temp
 
         # print reporting
         if self.time.hour % 2 == 0 and self.time.minute == 0:  # report every 2 hours
             print(f'\n\nTime: {str(self.time)}')
             print('\n\t* Observation Function:')
-            print(f'\t\tVars: {var_data}\n\t\tMeters: {meter_data}\n\t\tWeather:{weather_data}')
+            print(f'\t\tVars: {var_data}'  # outputs ordered list
+                  f'\n\t\tMeters: {meter_data}'  # outputs dictionary
+                  f'\n\t\tWeather:{weather_data}')  # outputs dictionary
             print(f'\t\tZone0 Temp: {round(self.zn0_temp,2)} C')
+            print(f'\t\tOutdoor Temp: {round(outdoor_temp, 2)} C')
 
     def actuation_function(self):
         work_hours_heating_setpoint = 18  # deg C
@@ -323,6 +327,7 @@ output_dfs['actuator'].plot(y='zn0_cooling_sp', use_index=True, ax=ax)
 plt.title('Zn0 Temps and Thermostat Setpoint for Year')
 
 # Analyze results in "out" folder, DView, or directly from your Python variables and Pandas Dataframes
+
 
 ```
 <ins>5 Zone Office Building Model</ins>

--- a/emspy/emspy.py
+++ b/emspy/emspy.py
@@ -289,8 +289,8 @@ class EmsPy:
                                                    ems_obj_details[2])  # actuator key
             # catch error handling by EMS E+
             if handle == -1:
-                raise Exception(f'ERROR: [{str(ems_obj_details)}]: The EMS sensor/actuator handle could not be'
-                                ' found. Please consult the .idf and/or your ToC for accuracy')
+                raise Exception(f'ERROR: [{str(ems_obj_details)}]: The EMS sensor/actuator handle could not be '
+                                'found. Please consult the .idf and/or your ToC for accuracy')
             else:
                 return handle
         except IndexError:

--- a/emspy/idf_editor.py
+++ b/emspy/idf_editor.py
@@ -80,13 +80,14 @@ def insert_custom_data_tracking(custom_name: str, idf_file_path: str, unit_type:
     output_var_obj = ['Output:Variable,',
                       custom_name,
                       '\tSchedule Value,',
-                      '\tTimestep;']
+                      '\tTimestep;',
+                      '! ----------------------------------------------------------------------']
 
     # create, write, then delete temporary file, used for appending
     temp_file = '_temp_write'
     with open(temp_file, 'w') as idf:
         idf.writelines('\n')
-        idf.writelines('!- Custom Schedule Tracking (next 3 objects)')
+        idf.writelines(f'!----------- Custom Schedule Tracking ({custom_name[:-1]}) -----------')
         idf.writelines('\n')
         idf.writelines('\n'.join(schedule_type_limit_obj))
         idf.writelines('\n\n')

--- a/emspy/idf_editor.py
+++ b/emspy/idf_editor.py
@@ -79,7 +79,7 @@ def insert_custom_data_tracking(custom_name: str, idf_file_path: str, unit_type:
 
     output_var_obj = ['Output:Variable,',
                       custom_name,
-                      '\tSchedule Value',
+                      '\tSchedule Value,',
                       '\tTimestep;']
 
     # create, write, then delete temporary file, used for appending

--- a/emspy/mdpmanager.py
+++ b/emspy/mdpmanager.py
@@ -212,8 +212,8 @@ class MdpManager:
         for i, ems_name in enumerate(ems_objects_or_names):
             # update current value
             value = ems_values[i]
-            ems_obj = self.get_mdp_element_from_ems_name(ems_name)
-            ems_name = self.get_ems_names_from_mdp_elements([ems_obj])[0]
+            ems_obj = self.get_mdp_element(ems_name)
+            ems_name = self.get_ems_names([ems_obj])[0]
             ems_obj.value = value  # update MdpElement
             values_dict[ems_name] = value  # update dict
 
@@ -237,8 +237,8 @@ class MdpManager:
 
         values_dict = {}
         for ems_name, value in bca_data_dict.items():
-            ems_obj = self.get_mdp_element_from_ems_name(ems_name)
-            ems_name = self.get_ems_names_from_mdp_elements([ems_obj])[0]
+            ems_obj = self.get_mdp_element(ems_name)
+            ems_name = self.get_ems_names([ems_obj])[0]
             ems_obj.value = value  # update MdpElement
             values_dict[ems_name] = value  # update dict
 
@@ -260,7 +260,7 @@ class MdpManager:
         values_dict = {}
         for ems_obj in ems_objects_or_names:
             # manage name or MdpElement input
-            ems_obj = self.get_mdp_element_from_ems_name(ems_obj)
+            ems_obj = self.get_mdp_element(ems_obj)
             values_dict[ems_obj.name] = ems_obj.value
 
         return values_dict
@@ -280,7 +280,7 @@ class MdpManager:
         encoded_values_dict = {}
         for ems_obj in ems_objects_or_names:
             # manage name or MdpElement input
-            ems_obj = self.get_mdp_element_from_ems_name(ems_obj)
+            ems_obj = self.get_mdp_element(ems_obj)
             encoded_value = ems_obj.encoded_value
 
             if encoded_value is None and ems_obj.encoding_fxn is not None:
@@ -291,7 +291,7 @@ class MdpManager:
 
         return encoded_values_dict
 
-    def get_ems_names_from_mdp_elements(self, ems_objects: list = None) -> list:
+    def get_ems_names(self, ems_objects: list = None) -> list:
         """
         From list of MdpElement objects, their names are returned in order. Will throw error if cannot find.
 
@@ -316,7 +316,7 @@ class MdpManager:
 
         return names_list
 
-    def get_mdp_element_from_ems_name(self, ems_name: str) -> MdpElement:
+    def get_mdp_element(self, ems_name: str) -> MdpElement:
         """
         Looks up and returns EMS object instance (MdpElement) from its name. Will throw error if cannot find.
 

--- a/emspy/mdpmanager.py
+++ b/emspy/mdpmanager.py
@@ -75,149 +75,6 @@ class MdpElement:
 class MdpManager:
     EMS_types = ('var', 'intvar', 'meter', 'weather', 'actuator')
 
-    def __init__(self):
-        """
-        A manager class for all the created EMS element objects. Each MDP element added creates a new MdpElement
-        instance and attribute referencing that MdpElement obj.
-        """
-        # store EMS element variable names and handle IDs
-        self.tc_var = {}
-        self.tc_intvar = {}
-        self.tc_meter = {}
-        self.tc_weather = {}
-        self.tc_actuator = {}
-
-        self.ems_type_dict = {'var': [], 'intvar': [], 'meter': [], 'weather': [], 'actuator': []}
-        self.ems_master_list = {}  # stores list of ALL MdpElemnts used
-
-    def add_ems_element(self,
-                        ems_type: str,
-                        ems_element_name: str,
-                        ems_handle_identifiers,
-                        encoding_fxn: Callable = None,
-                        *args):
-        """
-        Creates EMS element given its EMS type, variable name, handle identifiers, and optionally an encoding
-        function and its optional arguments. The adds this element to the proper MdpManager lists
-
-        :param ems_type: EMS type: ['var','intvar','meter','actuator','weather']
-        :param ems_element_name: Variable name of EMS element
-        :param ems_handle_identifiers: EMS element's handle identifiers used to fetch handle ID at start of simulation
-        :param encoding_fxn: Function to run when encoding the true values
-        :param args: Args of the encoding_fxn. DON'T included the EMS element value, that is included explicitly
-                     elsewhere and MUST be first argument of encoding_fxn when written. IF any arg is to be determined
-                     elsewhere manually (say, at runtime) then use NONE for that argument.
-        """
-        # input checking
-        if ems_type not in self.EMS_types:
-            raise ValueError(f'EMS Type must be in {self.EMS_types}')
-
-        ems_obj_name = ems_type + '_' + ems_element_name
-        setattr(self, ems_obj_name, MdpElement(ems_type,
-                                               ems_element_name,
-                                               ems_handle_identifiers,
-                                               encoding_fxn,
-                                               *args))
-
-        # add to existing attributes
-        getattr(self, 'tc_' + ems_type)[ems_element_name] = ems_handle_identifiers  # add to handle dict
-        ems_obj = getattr(self, ems_obj_name)
-        self.ems_type_dict[ems_type].append(ems_obj)
-        self.ems_master_list[ems_element_name] = ems_obj
-
-    def get_ems_names(self, ems_objects: [MdpElement] = None) -> list:
-        """From list of MdpElement objects, their names are returned in order."""
-
-        if None:
-            # All MdpElements
-            ems_objects = self.ems_master_list.values()
-
-        names_list = []
-        for ems_obj in ems_objects:
-            names_list.append(ems_obj.name)
-
-        return names_list
-
-    def update_ems_value(self, ems_objects: [MdpElement], ems_values: Sequence) -> dict:
-        """
-        Takes list of EMS objects and their values, stores all data, and returns encoded values in order of name list.
-
-        :param ems_objects: List of EMS name(s) that are tracked
-        :param ems_values: List of same EMS value(s) gathered from simulation runtime, in same order as names
-        :return: List of encoded values, in same order as names. If NO encoding function available, returns just value.
-        """
-        if len(ems_objects) != len(ems_values):
-            raise (f'EMS element names {ems_objects} and their values {ems_values} are out of sync. They '
-                   f'do not consist of the same number of values. They must align, element-wise.')
-
-        encoded_values = {}
-        for i, ems_obj in enumerate(ems_objects):
-            # update current value
-            val = ems_values[i]
-            ems_obj.value = val
-            if ems_obj.encoding_fxn is not None:
-                # if encoding function exists
-                val = self.run_encoding_fxn(ems_obj, val)
-            # return encoded val, or if not encoding return normal val
-            encoded_values[ems_obj.name] = val  # using ordered dict
-
-        return encoded_values
-
-    @staticmethod
-    def run_encoding_fxn(ems_object: MdpElement, value: float = None):
-        """This carefully runs the encoding function for a given EMS obj and value, returning the encoded value."""
-
-        # update encoded value
-        args = ems_object.encoding_fxn_args
-        if None in args:  # this handles encodings that must be handled manually in runtime
-            return None
-        if value is None:
-            # use stored value if not given from update
-            value = ems_object.value
-
-        # run encoding fxn
-        if args:  # if args exist
-            encoded_value = ems_object.encoding_fxn(value, *args)
-        else:  # if no args exist, empty
-            encoded_value = ems_object.encoding_fxn(value)
-        # obj update
-        ems_object.encoded_value = encoded_value
-        return encoded_value
-
-    def get_mdp_element_from_name(self, ems_name: str) -> MdpElement:
-        """Looks up and returns EMS object instance from its name."""
-        return self.ems_master_list[ems_name]
-
-    def read_ems_values(self, ems_objects: [MdpElement]):
-        """Iterates through list of EMS objects (or names) and returns fetched values dictionary."""
-
-        values_dict = {}
-        for ems_obj in ems_objects:
-            if type(ems_obj) == str:
-                ems_obj = self.get_mdp_element_from_name(ems_obj)
-            values_dict[ems_obj.name] = ems_obj.value
-
-        return values_dict
-
-    def read_ems_encoded_values(self, ems_objects: [MdpElement]):
-        """
-        Iterates through list of EMS objects and returns fetched encoded values dictionary.
-
-        IF the value is None, the encoding fxn will be reran before being returned. This is done to check if any new
-        information has been provided to the encoding arguments. Other elements without None value are NOT expected
-        to change between the usage of this function.
-        """
-
-        values_dict = {}
-        for ems_obj in ems_objects:
-            encoded_value = ems_obj.encoded_value
-            if encoded_value is None and ems_obj.encoding_fxn is not None:
-                # rerun in case of encoding fxn argument changes
-                encoded_value = self.run_encoding_fxn(ems_obj, ems_obj.value)
-            values_dict[ems_obj.name] = encoded_value
-
-        return values_dict
-
     @staticmethod
     def generate_mdp_from_tc(tc_intvars: dict = None,
                              tc_vars: dict = None,
@@ -286,3 +143,218 @@ class MdpManager:
                 mdp_instance.add_ems_element(ems_type, ems_name, *tc_values[0:])
 
         return mdp_instance
+
+    def __init__(self):
+        """
+        A manager class for all the created EMS element objects. Each MDP element added creates a new MdpElement
+        instance and attribute referencing that MdpElement obj.
+        """
+        # store EMS element variable names and handle IDs
+        self.tc_var = {}
+        self.tc_intvar = {}
+        self.tc_meter = {}
+        self.tc_weather = {}
+        self.tc_actuator = {}
+
+        self.ems_type_dict = {'var': [], 'intvar': [], 'meter': [], 'weather': [], 'actuator': []}
+        self.ems_master_list = {}  # stores list of ALL MdpElemnts used
+
+    def add_ems_element(self,
+                        ems_type: str,
+                        ems_element_name: str,
+                        ems_handle_identifiers,
+                        encoding_fxn: Callable = None,
+                        *args):
+        """
+        Creates EMS element given its EMS type, variable name, handle identifiers, and optionally an encoding
+        function and its optional arguments. The adds this element to the proper MdpManager lists
+
+        :param ems_type: EMS type: ['var','intvar','meter','actuator','weather']
+        :param ems_element_name: Variable name of EMS element
+        :param ems_handle_identifiers: EMS element's handle identifiers used to fetch handle ID at start of simulation
+        :param encoding_fxn: Function to run when encoding the true values
+        :param args: Args of the encoding_fxn. DON'T included the EMS element value, that is included explicitly
+                     elsewhere and MUST be first argument of encoding_fxn when written. IF any arg is to be determined
+                     elsewhere manually (say, at runtime) then use NONE for that argument.
+        """
+        # input checking
+        if ems_type not in self.EMS_types:
+            raise ValueError(f'EMS Type must be in {self.EMS_types}')
+
+        ems_obj_name = ems_type + '_' + ems_element_name
+        mdp_obj = MdpElement(ems_type,
+                             ems_element_name,
+                             ems_handle_identifiers,
+                             encoding_fxn,
+                             *args)
+        setattr(self, ems_obj_name, mdp_obj)
+
+        # add to existing attributes
+        getattr(self, 'tc_' + ems_type)[ems_element_name] = ems_handle_identifiers  # add to handle dict
+        ems_obj = getattr(self, ems_obj_name)
+        self.ems_type_dict[ems_type].append(ems_obj)
+        self.ems_master_list[ems_element_name] = ems_obj
+
+    def update_ems_value(self, ems_objects_or_names: list, ems_values: list) -> dict:
+        """
+        Takes list of EMS objects & their values, stores all data, automatically run any encoding functions and returns
+        the updated values in order of names list.
+
+        :param ems_objects_or_names: List of EMS name(s) or the associated MdpElements that are tracked
+        :param ems_values: List of same EMS's value(s) gathered from simulation at runtime, in same order as EMS elements
+        :return: Dict of updated values.
+        """
+        if len(ems_objects_or_names) != len(ems_values):
+            raise (f'EMS element names {ems_objects_or_names} and their values {ems_values} are out of sync. They '
+                   f'do not consist of the same number of values. They must align, element-wise.')
+
+        values_dict = {}
+        for i, ems_name in enumerate(ems_objects_or_names):
+            # update current value
+            value = ems_values[i]
+            ems_obj = self.get_mdp_element_from_ems_name(ems_name)
+            ems_name = self.get_ems_names_from_mdp_elements([ems_obj])[0]
+            ems_obj.value = value  # update MdpElement
+            values_dict[ems_name] = value  # update dict
+
+            # run encoding function on new data collected
+            if ems_obj.encoding_fxn is not None:
+                # if encoding function included for obj
+                self.run_encoding_fxn(ems_obj, value)
+
+        return values_dict
+
+    def update_ems_value_from_dict(self, bca_data_dict: dict) -> dict:
+        """
+        Takes a dictionary of str EMS names (key) and their simulation values (value), then stores all data, and
+        returns the encoded data as a similar dictionary.
+
+        This is meant to be used with BcaEnv.get_ems_values(.., return_dict = True) for more seamless data handling.
+
+        :param bca_data_dict: Dict of EMS names (key) and updated values from simulation (value)
+        :return: Dict of EMS names and their values.
+        """
+
+        values_dict = {}
+        for ems_name, value in bca_data_dict.items():
+            ems_obj = self.get_mdp_element_from_ems_name(ems_name)
+            ems_name = self.get_ems_names_from_mdp_elements([ems_obj])[0]
+            ems_obj.value = value  # update MdpElement
+            values_dict[ems_name] = value  # update dict
+
+            # run encoding function on new data collected
+            if ems_obj.encoding_fxn is not None:
+                # if encoding function included for obj
+                self.run_encoding_fxn(ems_obj, value)
+
+        return values_dict
+
+    def get_ems_values(self, ems_objects_or_names: list):
+        """
+        Iterates through list of EMS objects (or names) and returns fetched values dictionary.
+
+        :param ems_objects_or_names: List of EMS name(s) or the associated MdpElements that are tracked
+        :return: Dict of values.
+        """
+
+        values_dict = {}
+        for ems_obj in ems_objects_or_names:
+            # manage name or MdpElement input
+            ems_obj = self.get_mdp_element_from_ems_name(ems_obj)
+            values_dict[ems_obj.name] = ems_obj.value
+
+        return values_dict
+
+    def get_ems_encoded_values(self, ems_objects_or_names: list):
+        """
+        Iterates through list of EMS names or associated MdpElement objects & returns fetched encoded values dictionary.
+
+        IF the value is None, the encoding fxn will be reran before being returned. This is done to check if any new
+        information has been provided to the encoding arguments. Other elements without None value are NOT expected
+        to change between the usage of this function.
+
+        :param ems_objects_or_names: List of EMS name(s) or the associated MdpElements that are tracked
+        :return: Dict of encoded values. If NO encoding function available, returns just value.
+        """
+
+        encoded_values_dict = {}
+        for ems_obj in ems_objects_or_names:
+            # manage name or MdpElement input
+            ems_obj = self.get_mdp_element_from_ems_name(ems_obj)
+            encoded_value = ems_obj.encoded_value
+
+            if encoded_value is None and ems_obj.encoding_fxn is not None:
+                # rerun in case of encoding fxn argument changes
+                encoded_value = self.run_encoding_fxn(ems_obj, ems_obj.value)
+
+            encoded_values_dict[ems_obj.name] = encoded_value
+
+        return encoded_values_dict
+
+    def get_ems_names_from_mdp_elements(self, ems_objects: list = None) -> list:
+        """
+        From list of MdpElement objects, their names are returned in order. Will throw error if cannot find.
+
+        :returns : associated EMS object (MdpElement) name for that EMS MdpElement.
+        """
+
+        if None:
+            # All MdpElements
+            ems_objects = self.ems_master_list.values()
+
+        names_list = []
+        for ems_obj in ems_objects:
+
+            if isinstance(ems_obj, str):
+                if ems_objects not in self.ems_master_list:
+                    raise ValueError(f'This EMS name, {ems_obj}, is not a tracked MDP element.')
+                else:
+                    names_list.append(ems_obj)  # return itself since MdpElement NAME was already passed
+
+            else:
+                names_list.append(ems_obj.name)
+
+        return names_list
+
+    def get_mdp_element_from_ems_name(self, ems_name: str) -> MdpElement:
+        """
+        Looks up and returns EMS object instance (MdpElement) from its name. Will throw error if cannot find.
+
+        :returns : associated EMS object (MdpElement) for that EMS name.
+        """
+
+        if isinstance(ems_name, MdpElement):
+
+            return ems_name  # return itself since MdpElement was already passed
+
+        elif isinstance(ems_name, str):
+            try:
+                ems_obj = self.ems_master_list[ems_name]  # get MdpElement obj from its name
+            except KeyError(f'This EMS name, {ems_name}, is not a tracked MDP element.'):
+                ems_obj = None
+
+            return ems_obj
+
+    @staticmethod
+    def run_encoding_fxn(ems_object: MdpElement, value: float = None):
+        """This carefully runs the encoding function for a given EMS obj and value, returning the encoded value."""
+
+        # update encoded value
+        args = ems_object.encoding_fxn_args
+        if None in args:  # this handles encodings that must be handled manually in runtime
+            return None
+        if value is None:
+            # use stored value if not given from update
+            value = ems_object.value
+
+        # run encoding fxn
+        if args:  # if args exist
+            encoded_value = ems_object.encoding_fxn(value, *args)
+        else:  # if no args exist, empty
+            encoded_value = ems_object.encoding_fxn(value)
+        # obj update
+        ems_object.encoded_value = encoded_value
+        return encoded_value
+
+
+

--- a/emspy/mdpmanager.py
+++ b/emspy/mdpmanager.py
@@ -273,6 +273,8 @@ class MdpManager:
         information has been provided to the encoding arguments. Other elements without None value are NOT expected
         to change between the usage of this function.
 
+        If no encoding function is present, just the normal value is returned.
+
         :param ems_objects_or_names: List of EMS name(s) or the associated MdpElements that are tracked
         :return: Dict of encoded values. If NO encoding function available, returns just value.
         """
@@ -286,6 +288,9 @@ class MdpManager:
             if encoded_value is None and ems_obj.encoding_fxn is not None:
                 # rerun in case of encoding fxn argument changes
                 encoded_value = self.run_encoding_fxn(ems_obj, ems_obj.value)
+            else:
+                # no encoding value, return normal value
+                encoded_value = ems_obj.value
 
             encoded_values_dict[ems_obj.name] = encoded_value
 

--- a/example_usage/readme_example_simple_emspy_control.py
+++ b/example_usage/readme_example_simple_emspy_control.py
@@ -78,6 +78,7 @@ sim = BcaEnv(
     tc_weather=tc_weather
 )
 
+
 class Agent:
     """
     Create agent instance, which is used to create actuation() and observation() functions (both optional) and maintain
@@ -99,20 +100,23 @@ class Agent:
 
         # Get data from simulation at current timestep (and calling point) using ToC names
         var_data = self.bca.get_ems_data(list(self.bca.tc_var.keys()))
-        meter_data = self.bca.get_ems_data(list(self.bca.tc_meter.keys()))
-        weather_data = self.bca.get_ems_data(list(self.bca.tc_weather.keys()))
+        meter_data = self.bca.get_ems_data(list(self.bca.tc_meter.keys()), return_dict=True)
+        weather_data = self.bca.get_ems_data(list(self.bca.tc_weather.keys()), return_dict=True)
 
         # get specific values from MdpManager based on name
         self.zn0_temp = var_data[1]  # index 1st element to get zone temps, based on EMS Variable ToC
-        # OR
-        self.zn0_temp = self.bca.get_ems_data(['zn0_temp'])
+        # OR if using "return_dict=True"
+        outdoor_temp = weather_data['oa_db']  # outdoor air dry bulb temp
 
         # print reporting
         if self.time.hour % 2 == 0 and self.time.minute == 0:  # report every 2 hours
             print(f'\n\nTime: {str(self.time)}')
             print('\n\t* Observation Function:')
-            print(f'\t\tVars: {var_data}\n\t\tMeters: {meter_data}\n\t\tWeather:{weather_data}')
+            print(f'\t\tVars: {var_data}'  # outputs ordered list
+                  f'\n\t\tMeters: {meter_data}'  # outputs dictionary
+                  f'\n\t\tWeather:{weather_data}')  # outputs dictionary
             print(f'\t\tZone0 Temp: {round(self.zn0_temp,2)} C')
+            print(f'\t\tOutdoor Temp: {round(outdoor_temp, 2)} C')
 
     def actuation_function(self):
         work_hours_heating_setpoint = 18  # deg C

--- a/example_usage/readme_example_simple_emspy_control.py
+++ b/example_usage/readme_example_simple_emspy_control.py
@@ -20,6 +20,8 @@ idf_file_name = r'BEM_simple/simple_office_5zone_April.idf'  # building energy m
 # Weather Path
 ep_weather_path = r'BEM_simple/5B_USA_CO_BOULDER_TMY2.epw'  # EPW weather file
 
+# Output .csv Path (optional)
+cvs_output_path = r'dataframes_output_test.csv'
 
 # STATE SPACE (& Auxiliary Simulation Data)
 
@@ -173,7 +175,7 @@ sim.run_env(ep_weather_path)
 sim.reset_state()  # reset when done
 
 # -- Sample Output Data --
-output_dfs = sim.get_df()  # LOOK at all the data collected here, custom DFs can be made too
+output_dfs = sim.get_df(to_csv_file=cvs_output_path)  # LOOK at all the data collected here, custom DFs can be made too
 
 # -- Plot Results --
 fig, ax = plt.subplots()

--- a/example_usage/simple_emspy_control.py
+++ b/example_usage/simple_emspy_control.py
@@ -156,10 +156,10 @@ class Agent:
         self.actuators = mdp.ems_type_dict['actuator']  # all MdpElements of EMS type actuator
 
         # get just the names of EMS variables to use with other functions
-        self.var_names = mdp.get_ems_names_from_mdp_elements(self.vars)
-        self.meter_names = mdp.get_ems_names_from_mdp_elements(self.meters)
-        self.weather_names = mdp.get_ems_names_from_mdp_elements(self.weather)
-        self.actuator_names = mdp.get_ems_names_from_mdp_elements(self.actuators)
+        self.var_names = mdp.get_ems_names(self.vars)
+        self.meter_names = mdp.get_ems_names(self.meters)
+        self.weather_names = mdp.get_ems_names(self.weather)
+        self.actuator_names = mdp.get_ems_names(self.actuators)
 
         # simulation data state
         self.zn0_temp = None  # deg C
@@ -170,9 +170,9 @@ class Agent:
 
     def observation_function(self):
         # -- FETCH/UPDATE SIMULATION DATA --
+        # Get data from simulation at current timestep (and calling point)
         self.time = self.bca.get_ems_data(['t_datetimes'])
 
-        # Get data from simulation at current timestep (and calling point)
         var_data = self.bca.get_ems_data(self.var_names)
         meter_data = self.bca.get_ems_data(self.meter_names, return_dict=True)
         weather_data = self.bca.get_ems_data(self.weather_names, return_dict=True)  # just for example, other usage
@@ -189,7 +189,7 @@ class Agent:
         Note: not all usage examples are presented below.
         """
         # Get specific values from MdpManager based on name
-        self.zn0_temp = self.mdp.get_mdp_element_from_ems_name('zn0_temp').value
+        self.zn0_temp = self.mdp.get_mdp_element('zn0_temp').value
         # OR get directly from BcaEnv
         self.zn0_temp = self.bca.get_ems_data(['zn0_temp'])
         # OR directly from output
@@ -201,7 +201,7 @@ class Agent:
 
         # use encoding function values to see temperature in Fahrenheit
         zn0_temp_f = self.mdp.ems_master_list['zn0_temp'].encoded_value  # access the Master list dictionary directly
-        outdoor_temp_f = self.mdp.get_mdp_element_from_ems_name('oa_db').encoded_value  # using helper function
+        outdoor_temp_f = self.mdp.get_mdp_element('oa_db').encoded_value  # using helper function
         # OR call encoding function on multiple elements, even though encoded values are automatically up to date
         encoded_values_dict = self.mdp.get_ems_encoded_values(['oa_db', 'zn0_temp'])
         zn0_temp_f = encoded_values_dict['zn0_temp']

--- a/example_usage/simple_emspy_control.py
+++ b/example_usage/simple_emspy_control.py
@@ -156,10 +156,10 @@ class Agent:
         self.actuators = mdp.ems_type_dict['actuator']  # all MdpElements of EMS type actuator
 
         # get just the names of EMS variables to use with other functions
-        self.var_names = mdp.get_ems_names(self.vars)
-        self.meter_names = mdp.get_ems_names(self.meters)
-        self.weather_names = mdp.get_ems_names(self.weather)
-        self.actuator_names = mdp.get_ems_names(self.actuators)
+        self.var_names = mdp.get_ems_names_from_mdp_elements(self.vars)
+        self.meter_names = mdp.get_ems_names_from_mdp_elements(self.meters)
+        self.weather_names = mdp.get_ems_names_from_mdp_elements(self.weather)
+        self.actuator_names = mdp.get_ems_names_from_mdp_elements(self.actuators)
 
         # simulation data state
         self.zn0_temp = None  # deg C
@@ -174,23 +174,46 @@ class Agent:
 
         # Get data from simulation at current timestep (and calling point)
         var_data = self.bca.get_ems_data(self.var_names)
-        meter_data = self.bca.get_ems_data(self.meter_names)
-        weather_data = self.bca.get_ems_data(self.weather_names)
+        meter_data = self.bca.get_ems_data(self.meter_names, return_dict=True)
+        weather_data = self.bca.get_ems_data(self.weather_names, return_dict=True)  # just for example, other usage
 
-        # update our MdpManager and all MdpElements, automatically calling any encoding/normalization functions
-        vars = self.mdp.update_ems_value(self.vars, var_data)
-        meters = self.mdp.update_ems_value(self.meters, meter_data)
-        weather = self.mdp.update_ems_value(self.weather, weather_data)
+        # Update our MdpManager and all MdpElements, returns same values
+        # Automatically runs any encoding functions to update encoded values
+        vars = self.mdp.update_ems_value(self.vars, var_data)  # outputs dict based on ordered list of names & values
+        meters = self.mdp.update_ems_value_from_dict(meter_data)  # other usage, outputs same dict w/ dif input
+        weather = self.mdp.update_ems_value_from_dict(weather_data)   # other usage, outputs same dict w/ dif input
 
-        # get specific values from MdpManager based on name
-        self.zn0_temp = self.mdp.get_mdp_element_from_name('zn0_temp').value
+        """
+        Below, we show various redundant ways of looking at EMS values and encoded values. A variety of approaches are 
+        provided for a variety of use-cases. Please inspect the usage and code to see what best suites your needs. 
+        Note: not all usage examples are presented below.
+        """
+        # Get specific values from MdpManager based on name
+        self.zn0_temp = self.mdp.get_mdp_element_from_ems_name('zn0_temp').value
+        # OR get directly from BcaEnv
+        self.zn0_temp = self.bca.get_ems_data(['zn0_temp'])
+        # OR directly from output
+        self.zn0_temp = var_data[1]  # from BcaEnv list output
+        self.zn0_temp = vars['zn0_temp']  # from MdpManager list output
+        # outdoor air dry bulb temp
+        outdoor_temp = weather_data['oa_db']  # from BcaEnv dict output
+        outdoor_temp = weather['oa_db']  # from MdpManager dict output
+
+        # use encoding function values to see temperature in Fahrenheit
+        zn0_temp_f = self.mdp.ems_master_list['zn0_temp'].encoded_value  # access the Master list dictionary directly
+        outdoor_temp_f = self.mdp.get_mdp_element_from_ems_name('oa_db').encoded_value  # using helper function
+        # OR call encoding function on multiple elements, even though encoded values are automatically up to date
+        encoded_values_dict = self.mdp.get_ems_encoded_values(['oa_db', 'zn0_temp'])
+        zn0_temp_f = encoded_values_dict['zn0_temp']
+        outdoor_temp_f = encoded_values_dict['oa_db']
 
         # print reporting
-        if self.time.hour % self.print_every_x_hours == 0 and self.time.minute == 0:
+        if self.time.hour % 2 == 0 and self.time.minute == 0:  # report every 2 hours
             print(f'\n\nTime: {str(self.time)}')
             print('\n\t* Observation Function:')
-            print(f'\t\tVars: {vars}\n\t\tMeters: {meters}\n\t\tWeather:{weather}')
-            print(f'\t\tZone0 Temp: {round(self.zn0_temp,2)} C')
+            print(f'\t\tVars: {var_data}\n\t\tMeters: {meter_data}\n\t\tWeather:{weather_data}')
+            print(f'\t\tZone0 Temp: {round(self.zn0_temp,2)} C, {round(zn0_temp_f,2)} F')
+            print(f'\t\tOutdoor Temp: {round(outdoor_temp, 2)} C, {round(outdoor_temp_f,2)} F')
 
     def actuation_function(self):
         work_hours_heating_setpoint = 18  # deg C


### PR DESCRIPTION
Added extra features to all data tracking and calling methods. Added optional dictionary output that pairs EMS names with their values, not just an ordered list. This is a more organized way to get EMS output data.
These changes relate to the BcaEnv interface, then I had to update MdpManager to reflect these changes